### PR TITLE
Cater for LLPC moving into an llpc subdirectory: attempt 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Cater for LLPC moving into an llpc subdirectory in its repository.
 if (EXISTS ${PROJECT_SOURCE_DIR}/../llpc/llpc/CMakeLists.txt)
   set(XGL_LLPC_PATH ${PROJECT_SOURCE_DIR}/../llpc/llpc CACHE PATH "Specify the path to the LLPC." FORCE)
-else()
+elseif (EXISTS ${PROJECT_SOURCE_DIR}/../llpc/CMakeLists.txt)
   set(XGL_LLPC_PATH ${PROJECT_SOURCE_DIR}/../llpc CACHE PATH "Specify the path to the LLPC." FORCE)
 endif()
 


### PR DESCRIPTION
The previous fix broke the case of using cmake with a non-standard
directory structure and manually specifying XGL_LLPC_PATH.