### PR TITLE
Make XGL_LLPC_INC_DIR overridable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,9 @@ else()
 endif()
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/../llpc/include)
-    set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/include)
+    set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/include CACHE PATH "The path of llpc.h for spvgen")
 else()
-    set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/llpc/include)
+    set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/llpc/include CACHE PATH "The path of llpc.h for spvgen")
 endif()
 
 include_directories(


### PR DESCRIPTION
This is needed when doing a cmake build on a non-standard directory
structure.

Change-Id: I4a8750e42992b4127084183b969fe1558379f41e