### PR TITLE
Fixed include path for llpc.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,7 @@ else()
     set(XGL_VFX_PATH ${PROJECT_SOURCE_DIR}/../llpc/llpc/tool/vfx CACHE PATH "The path of vfx.")
 endif()
 
-if(EXISTS ${PROJECT_SOURCE_DIR}/../llpc/include)
-    set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/include CACHE PATH "The path of llpc.h for spvgen")
-else()
-    set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/llpc/include CACHE PATH "The path of llpc.h for spvgen")
-endif()
+set(XGL_LLPC_INC_DIR ${PROJECT_SOURCE_DIR}/../llpc/llpc/include CACHE PATH "The path of llpc.h for spvgen")
 
 include_directories(
 	include


### PR DESCRIPTION
With llpc PR489 introducing a file include/vkgcDefs.h, the CMakeLists
code in spvgen to find llpc.h is now wrong. This comit fixes that.

(A future commit will change this again to include vkgcDefs.h directly.)