### PR TITLE
Fix up "Support the move of vfx directory"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ endif ()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(XGL_LLPC_PATH ${PROJECT_SOURCE_DIR}/../llpc/llpc CACHE PATH "Specify the path to the LLPC." FORCE)
+if("${XGL_LLPC_PATH}" STREQUAL "")
+    set(XGL_LLPC_PATH ${PROJECT_SOURCE_DIR}/../llpc/llpc)
+endif()
 
 set(VULKAN_HEADER_PATH ${PROJECT_SOURCE_DIR}/../xgl/icd/api/include/khronos CACHE PATH "Specify the path to vulkan header files.")
 


### PR DESCRIPTION
That last change caused a failure doing a cmake build with an unusual
directory structure manually specifying XGL_LLPC_PATH. Fixed.

Change-Id: If40995b8cd6d7e602498bf41f1b758aa97af3ca2