### PR TITLE
Fixed spvgen CMakeLists.txt for change to XGL_VKGC_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,10 @@ set_target_properties(spvgen PROPERTIES PREFIX "")
 
 # vkgcDefs.h is included in llpc/tool/vfx/vfx.h
 # llpc.h is included in llpc/llpc/tool/vfx/vfx.h
-if(EXISTS ${XGL_LLPC_PATH}/../tool/vfx/vfx.h)
+if(EXISTS ${XGL_VKGC_PATH}/tool/vfx/vfx.h)
+    set(XGL_VFX_PATH ${XGL_VKGC_PATH}/tool/vfx)
+    set(XGL_LLPC_INC_DIR ${XGL_VKGC_PATH}/include)
+elseif(EXISTS ${XGL_LLPC_PATH}/../tool/vfx/vfx.h)
     set(XGL_VFX_PATH ${XGL_LLPC_PATH}/../tool/vfx)
     set(XGL_LLPC_INC_DIR ${XGL_LLPC_PATH}/../include)
 else()


### PR DESCRIPTION
The XGL CMakeLists.txt is changing to set (or allow the user to set)
XGL_VKGC_PATH instead of XGL_LLPC_PATH.

Change-Id: I63303db3160ccad6eb63f4504a33aaf25d5fe64a
Pull-Request: https://github.com/GPUOpen-Drivers/spvgen/pull/13
Author: Tim Renouf <tim.renouf@amd.com>