### PR TITLE
Fix spvgen build in internal test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ include_directories(
 	${XGL_VFX_PATH}
 )
 
-if(EXISTS ${XGL_VKGC_PATH}/tool/vfx/vfxVkSection.cpp)
+if(EXISTS ${XGL_VFX_PATH}/vfxVkSection.cpp)
     add_definitions(-DVFX_SUPPORT_VK_PIPELINE=1)
     add_definitions(-DVFX_SUPPORT_RENDER_DOCOUMENT=1)
     target_sources(spvgen PRIVATE


### PR DESCRIPTION
Use XGL_VFX_PATH instead of XGL_VKGC_PATH to check vfxVkSection.cpp
Internal build only set macro XGL_LLPC_PATH