### PR TITLE
spvgen cmake: depend on khronos_spirv_interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,4 +115,4 @@ else()
     )
 endif()
 
-target_link_libraries(spvgen glslang HLSL OGLCompiler SPIRV SPIRV-Tools SPIRV-Tools-opt spirv-cross-c khronos_vulkan_interface)
+target_link_libraries(spvgen glslang HLSL OGLCompiler SPIRV SPIRV-Tools SPIRV-Tools-opt spirv-cross-c khronos_spirv_interface khronos_vulkan_interface)


### PR DESCRIPTION
We seem to get away without that in a normal driver cmake build, but we
need it for an LLPC standalone build.

Change-Id: I0a3a4c3bddb3826f3631ce834b5756532d34ad87