### PR TITLE
Update spvgen header

### DIFF
--- a/include/spvgen.h
+++ b/include/spvgen.h
@@ -98,10 +98,12 @@ enum SpvSourceLanguage : uint32_t
 };
 enum SpvGenStage : uint32_t
 {
+    SpvGenStageTask,
     SpvGenStageVertex,
     SpvGenStageTessControl,
     SpvGenStageTessEvaluation,
     SpvGenStageGeometry,
+    SpvGenStageMesh,
     SpvGenStageFragment,
     SpvGenStageCompute,
     SpvGenStageRayTracingRayGen,


### PR DESCRIPTION
Add mesh shader stages to spvgen. Also, add a conversion helper to do
the conversion from spvgen stages to glslang stages. We couldn't static
cast the types since the enumerants may not be identical.