### PR TITLE
Generate static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,6 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/external/SPIRV-cross/CMakeLists.txt)
     add_subdirectory(external/SPIRV-cross)
 endif()
 
-add_library(spvgen SHARED "")
-
-set_target_properties(spvgen PROPERTIES PREFIX "")
-
 # vkgcDefs.h is included in llpc/tool/vfx/vfx.h
 # llpc.h is included in llpc/llpc/tool/vfx/vfx.h
 if(EXISTS ${XGL_VKGC_PATH}/tool/vfx/vfx.h)
@@ -92,7 +88,7 @@ include_directories(
 if(EXISTS ${XGL_VFX_PATH}/vfxVkSection.cpp)
     add_definitions(-DVFX_SUPPORT_VK_PIPELINE=1)
     add_definitions(-DVFX_SUPPORT_RENDER_DOCOUMENT=1)
-    target_sources(spvgen PRIVATE
+    set(SPVGEN_SOURCE_FILES
         source/spvgen.cpp
         ${XGL_VFX_PATH}/vfxParser.cpp
         ${XGL_VFX_PATH}/vfxPipelineDoc.cpp
@@ -103,7 +99,7 @@ if(EXISTS ${XGL_VFX_PATH}/vfxVkSection.cpp)
         ${XGL_VFX_PATH}/vfxRenderSection.cpp
     )
 else()
-    target_sources(spvgen PRIVATE
+    set(SPVGEN_SOURCE_FILES
         source/spvgen.cpp
         ${XGL_VFX_PATH}/vfxParser.cpp
         ${XGL_VFX_PATH}/vfxPipelineDoc.cpp
@@ -113,4 +109,22 @@ else()
     )
 endif()
 
-target_link_libraries(spvgen glslang HLSL OGLCompiler SPIRV SPIRV-Tools SPIRV-Tools-opt spirv-cross-c khronos_spirv_interface khronos_vulkan_interface)
+# Build object library
+add_library(spvgen_base OBJECT ${SPVGEN_SOURCE_FILES})
+target_link_libraries(spvgen_base glslang HLSL OGLCompiler SPIRV SPIRV-Tools SPIRV-Tools-opt spirv-cross-c khronos_spirv_interface khronos_vulkan_interface)
+
+# Touch an empty source file
+set(EMPTY_SOURCE_FILES ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp)
+add_custom_command(
+    OUTPUT  ${EMPTY_SOURCE_FILES}
+    COMMAND ${CMAKE_COMMAND} -E touch ${EMPTY_SOURCE_FILES}
+    COMMENT "Touching ${EMPTY_SOURCE_FILES}"
+)
+
+# Build static library
+add_library(spvgen_static STATIC ${EMPTY_SOURCE_FILES})
+target_link_libraries(spvgen_static spvgen_base)
+
+# Build shared library
+add_library(spvgen SHARED ${EMPTY_SOURCE_FILES})
+target_link_libraries(spvgen spvgen_base)

--- a/include/spvgen.h
+++ b/include/spvgen.h
@@ -240,11 +240,9 @@ void SH_IMPORT_EXPORT vfxPrintDoc(
 }
 #endif
 
-static inline bool InitSpvGen(
-    const char* pSpvGenDir = nullptr)
-{
-    return true;
-}
+bool InitSpvGen(const char* pSpvGenDir = nullptr);
+
+void FinalizeSpvgen();
 
 #else
 
@@ -390,6 +388,8 @@ DECL_EXPORT_FUNC(vfxGetPipelineDoc);
 DECL_EXPORT_FUNC(vfxPrintDoc);
 
 bool SPVAPI InitSpvGen(const char* pSpvGenDir = nullptr);
+
+void SPVAPI FinalizeSpvgen();
 
 #endif
 
@@ -552,6 +552,10 @@ bool SPVAPI InitSpvGen(
     }
     return success;
 }
+
+// =====================================================================================================================
+// Finalize spvgen; Clean up resource
+void SPVAPI FinalizeSpvgen() {}
 
 #endif
 

--- a/source/spvgen.cpp
+++ b/source/spvgen.cpp
@@ -1747,6 +1747,41 @@ spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic, char* pBuffer, 
 }
 
 // =====================================================================================================================
+// Internal initilization
+static void internalInit()
+{
+    static bool init = false;
+    if (!init) {
+        ProcessConfigFile();
+        glslang::InitializeProcess();
+        spv::Parameterize();
+        init = true;
+    }
+}
+
+// =====================================================================================================================
+// Cleanup
+static void internalFinal()
+{
+    glslang::FinalizeProcess();
+}
+
+// =====================================================================================================================
+// Initilize the static library
+bool InitSpvGen(const char* pSpvGenDir)
+{
+    internalInit();
+    return true;
+}
+
+// =====================================================================================================================
+// Finalize the static library
+void FinalizeSpvgen()
+{
+    internalFinal();
+}
+
+// =====================================================================================================================
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
@@ -1758,16 +1793,14 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
-        ProcessConfigFile();
-        glslang::InitializeProcess();
-        spv::Parameterize();
+        internalInit();
         break;
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:
         break;
     case DLL_PROCESS_DETACH:
-        glslang::FinalizeProcess();
+        internalFinal();
         break;
     }
     return TRUE;


### PR DESCRIPTION
Amdllpc requires to link spvgen statically, so add build info to
generate static library. The static will depend on amdllpc build.

Add two internal functions, they are not exported and they are called
when process is initialized and terminated with using static library.
Add a interface "FinalizeSpvgen" which clean up resouces.