### PR TITLE
Make sure that library names are consistent with lib prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,3 +135,4 @@ target_link_libraries(spvgen_static spvgen_base)
 # Build shared library
 add_library(spvgen SHARED ${EMPTY_SOURCE_FILES})
 target_link_libraries(spvgen spvgen_base)
+set_target_properties(spvgen PROPERTIES PREFIX "")


### PR DESCRIPTION
A recent change meant that the library prefix changed on some platforms. Fix it
so it is the same as before (no lib prefix), libraries are consistently
spvgen.dll or spvgen.so