### PR TITLE
Remove double init and finalize

### DIFF
--- a/source/spvgen.cpp
+++ b/source/spvgen.cpp
@@ -1778,7 +1778,6 @@ static void internalFinal()
 // Initilize the static library
 bool InitSpvGen(const char* pSpvGenDir)
 {
-    internalInit();
     return true;
 }
 
@@ -1786,7 +1785,6 @@ bool InitSpvGen(const char* pSpvGenDir)
 // Finalize the static library
 void FinalizeSpvgen()
 {
-    internalFinal();
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The glsl init and finalize functions are already called when the library
is loaded and unloaded, it asserts when being called twice.

Should fix the llpc tests from https://github.com/GPUOpen-Drivers/llpc/pull/1774.